### PR TITLE
manifest: Bump numpy version to 2.0.0

### DIFF
--- a/org.sugarlabs.Measure.json
+++ b/org.sugarlabs.Measure.json
@@ -32,8 +32,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-                    "sha256": "7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e",
+                    "url": "https://files.pythonhosted.org/packages/cd/37/595f27a95ff976e8086bc4be1ede21ed24ca4bc127588da59197a65d066f/numpy-2.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+                    "sha256": "5f64641b42b2429f56ee08b4f427a4d2daf916ec59686061de751a55aafa22e4",
                     "only-arches": ["aarch64"],
                     "x-checker-data": {
                         "type": "json",
@@ -46,8 +46,8 @@
                },
                {
                 "type": "file",
-                "url": "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-                "sha256": "666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5",
+                "url": "https://files.pythonhosted.org/packages/d1/27/2a7bd6855dc717aeec5f553073a3c426b9c816126555f8e616392eab856b/numpy-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                "sha256": "a7039a136017eaa92c1848152827e1424701532ca8e8967fe480fe1569dae581",
                 "only-arches": ["x86_64"],
                 "x-checker-data": {
                     "type": "json",


### PR DESCRIPTION
Updated `numpy` to version 2.0.0

Tested it locally and was working correctly.